### PR TITLE
Per-protocol analysis

### DIFF
--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -84,6 +84,7 @@ if(Sys.getenv("OPENSAFELY_BACKEND") %in% c("", "expectations")){
                  period_2month = runif(1, 0, 6) %>% ceiling(),
                  period_3month = runif(1, 0, 4) %>% ceiling(), 
                  period_week = runif(1, 0, 52) %>% ceiling(),
+                 covid_test_positive_date = sample(seq(ymd("20220210"), ymd("20230209"), by = 1), 1),
                  tb_postest_vacc_cat = sample(c(">= 84 days or unknown", "< 7 days", "7-27 days", "28-83 days"), 1) %>%
                    factor(levels = c(">= 84 days or unknown", "< 7 days", "7-27 days", "28-83 days"))) %>%
           ungroup() %>%

--- a/analysis/seq_trials/functions/add_ipacw.R
+++ b/analysis/seq_trials/functions/add_ipacw.R
@@ -1,0 +1,53 @@
+add_ipacw <- function(trials, treatment_window = 5, covars){
+  trials_4 <-
+    trials %>%
+    filter(trial == 4) %>% # no individuals starting treatment by default
+    mutate(ipacw_lag_cumprod = 1)
+  trials_ipacw_added <-
+    map(.x = 0:3,
+        .f = ~ add_ipacw_trial_no(trials, treatment_window, .x, covars)) %>% 
+    bind_rows() %>%
+    bind_rows(., trials_4)
+  
+}
+add_ipacw_trial_no <- function(trials, treatment_window, trial_no, covars){
+  tend_max <- treatment_window - trial_no - 1
+  trials_no <-
+    trials %>%
+    filter(trial == {{trial_no}}, arm == 0, tend <= {tend_max + 1}) %>%
+    group_by(patient_id, trial) %>%
+    mutate(treatment_seq_lead1 = lead(treatment_seq, n = 1L, default = NA), 
+           treatment_seq_next_equal_to_arm = if_else(treatment_seq_lead1 == arm, 1L, 0L)) %>%
+    filter(treatment_seq != 1 & tend <= tend_max) %>%
+    ungroup()
+  if (tend_max > 1){
+    formula_num <- "treatment_seq_next_equal_to_arm ~ factor(tend)" %>% as.formula()
+    formula_denom <- paste0("treatment_seq_next_equal_to_arm ~ ",
+                            paste0(c("factor(tend) + ns(covid_test_positive_date, 3)", covars), 
+                                   collapse = " + ")) %>% as.formula()
+  } else if (tend_max == 1){
+    formula_num <- "treatment_seq_next_equal_to_arm ~ 1" %>% as.formula()
+    formula_denom <- paste0("treatment_seq_next_equal_to_arm ~ ",
+                            paste0(c("ns(covid_test_positive_date, 3)", covars), 
+                                   collapse = " + ")) %>% as.formula()
+  }
+  fit_num <- glm(formula_num,
+                 family = binomial(link = "logit"),
+                 data = trials_no)
+  fit_denom <- glm(formula_denom,
+                   family = binomial(link = "logit"),
+                   data = trials_no)
+  trials_no <-
+    trials_no %>%
+    mutate(num = predict(fit_num, newdata = ., type = "response"),  
+           denom = predict(fit_denom, newdata =., type = "response"),
+           ipacw = num / denom) %>%
+    select(patient_id, trial, tstart, tend, ipacw)
+  trials %>%
+    filter(trial == {{trial_no}} & !(arm == 0 & treatment_seq == 1)) %>%
+    left_join(trials_no, by = c("patient_id", "trial", "tstart", "tend")) %>%
+    mutate(ipacw = if_else(is.na(ipacw), 1, ipacw)) %>%
+    group_by(patient_id) %>%
+    mutate(ipacw_lag = lag(ipacw, n = 1, default = 1L),
+           ipacw_lag_cumprod = cumprod(ipacw_lag))
+}

--- a/analysis/seq_trials/functions/add_ipacw.R
+++ b/analysis/seq_trials/functions/add_ipacw.R
@@ -1,47 +1,50 @@
 add_ipacw <- function(trials, treatment_window = 5, covars){
   trials_4 <-
     trials %>%
-    filter(trial == 4) %>% # no individuals starting treatment by default
+    filter(trial == 4) %>% # no individuals starting treatment by design
     mutate(ipacw_lag_cumprod = 1)
   trials_ipacw_added <-
     map(.x = 0:3,
         .f = ~ add_ipacw_trial_no(trials, treatment_window, .x, covars)) %>% 
     bind_rows() %>%
     bind_rows(., trials_4)
-  
 }
 add_ipacw_trial_no <- function(trials, treatment_window, trial_no, covars){
   tend_max <- treatment_window - trial_no - 1
   trials_no <-
     trials %>%
     filter(trial == {{trial_no}}, arm == 0, tend <= {tend_max + 1}) %>%
-    group_by(patient_id, trial) %>%
+    group_by(patient_id) %>%
     mutate(treatment_seq_lead1 = lead(treatment_seq, n = 1L, default = NA), 
-           treatment_seq_next_equal_to_arm = if_else(treatment_seq_lead1 == arm, 1L, 0L)) %>%
-    filter(treatment_seq != 1 & tend <= tend_max) %>%
+           treatment_seq_lead1_equal_to_arm = if_else(treatment_seq_lead1 == arm, 1L, 0L)) %>%
+    filter(treatment_seq != 1 & tend <= tend_max) %>% # censor and only select intervals where there is a chance someone starts treatment
     ungroup()
+  #formula_num <- "treatment_seq_lead1_equal_to_arm ~ 1" %>% as.formula()
   if (tend_max > 1){
-    formula_num <- "treatment_seq_next_equal_to_arm ~ factor(tend)" %>% as.formula()
-    formula_denom <- paste0("treatment_seq_next_equal_to_arm ~ ",
-                            paste0(c("factor(tend) + ns(covid_test_positive_date, 3)", covars), 
+    formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ ",
+                            paste0(c("factor(tend)"),
                                    collapse = " + ")) %>% as.formula()
+    # formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ ",
+    #                         paste0(c("factor(tend) + ns(covid_test_positive_date, 3)", covars), 
+    #                                collapse = " + ")) %>% as.formula()
   } else if (tend_max == 1){
-    formula_num <- "treatment_seq_next_equal_to_arm ~ 1" %>% as.formula()
-    formula_denom <- paste0("treatment_seq_next_equal_to_arm ~ ",
-                            paste0(c("ns(covid_test_positive_date, 3)", covars), 
-                                   collapse = " + ")) %>% as.formula()
+    formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ 1") %>% as.formula()
+    # formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ ",
+    #                         paste0(c("ns(covid_test_positive_date, 3)", covars), 
+    #                                collapse = " + ")) %>% as.formula()
   }
-  fit_num <- glm(formula_num,
-                 family = binomial(link = "logit"),
-                 data = trials_no)
+  # fit_num <- glm(formula_num,
+  #                family = binomial(link = "logit"),
+  #                data = trials_no)
   fit_denom <- glm(formula_denom,
                    family = binomial(link = "logit"),
                    data = trials_no)
   trials_no <-
     trials_no %>%
-    mutate(num = predict(fit_num, newdata = ., type = "response"),  
+    mutate(#num = predict(fit_num, newdata = ., type = "response"),  
            denom = predict(fit_denom, newdata =., type = "response"),
-           ipacw = num / denom) %>%
+           #ipacw = num / denom
+           ipacw = 1 / denom) %>%
     select(patient_id, trial, tstart, tend, ipacw)
   trials %>%
     filter(trial == {{trial_no}} & !(arm == 0 & treatment_seq == 1)) %>%

--- a/analysis/seq_trials/functions/add_ipacw.R
+++ b/analysis/seq_trials/functions/add_ipacw.R
@@ -25,12 +25,12 @@ add_ipacw_trial_no <- function(trials, treatment_window, trial_no, covars){
     #                         paste0(c("factor(tend)"),
     #                                collapse = " + ")) %>% as.formula()
     formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ ",
-                            paste0(c("factor(tend) + ns(covid_test_positive_date, 3)", covars),
+                            paste0(c("factor(tend) + ns(covid_test_positive_date, 3) + period", covars),
                                    collapse = " + ")) %>% as.formula()
   } else if (tend_max == 1){
     # formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ 1") %>% as.formula()
     formula_denom <- paste0("treatment_seq_lead1_equal_to_arm ~ ",
-                            paste0(c("ns(covid_test_positive_date, 3)", covars),
+                            paste0(c("ns(covid_test_positive_date, 3) + period", covars),
                                    collapse = " + ")) %>% as.formula()
   }
   # fit_num <- glm(formula_num,

--- a/analysis/seq_trials/pp_analysis.R
+++ b/analysis/seq_trials/pp_analysis.R
@@ -62,8 +62,8 @@ trials <- arrow::read_feather(here("output", "data", "data_seq_trials_monthly.fe
 
 ################################################################################
 # 1.0 IPACW
-# trials_ipacw_added <- 
-#   add_ipacw(trials, covars) TO FIX: MAKE THIS WORK!!!
+trials_ipacw_added <-
+  add_ipacw(trials = trials, covars = covars)
 
 ################################################################################
 # 1.0 Outcome model

--- a/analysis/seq_trials/pp_analysis.R
+++ b/analysis/seq_trials/pp_analysis.R
@@ -1,0 +1,170 @@
+################################################################################
+#
+# PER PROTOCOL ANALYSIS
+# 
+# 
+# The output of this script is:
+# csv file ./output/seq_trials/pp/data_flow_seq_trials_*.csv
+# where * is monthly or weekly (_red for redacted file)
+################################################################################
+
+################################################################################
+# 0.0 Import libraries + functions
+################################################################################
+library(readr)
+library(magrittr)
+library(dplyr)
+library(tidyr)
+library(fs)
+library(here)
+library(purrr)
+library(splines)
+library(broom)
+library(sandwich)
+library(lmtest)
+library(data.table)
+library(optparse)
+library(tictoc)
+source(here::here("lib", "design", "covars_seq_trials.R"))
+
+################################################################################
+# 0.1 Create directories for output
+################################################################################
+output_dir <- here::here("output", "seq_trials", "pp")
+fs::dir_create(output_dir)
+
+################################################################################
+# 0.2 Import command-line arguments
+################################################################################
+args <- commandArgs(trailingOnly=TRUE)
+if(length(args)==0){
+  # use for interactive testing
+  model <- "simple"
+} else {
+  
+  option_list <- list(
+    make_option("--model", type = "character", default = "simple",
+                help = "Outcome model fitted. Choice between simple (main effects arm, period and trial), interaction_period (introducing interaction between arm and period), interaction_trial (introducing interaction between arm and trial), interaction_all (introducing interaction between arm and period; arm and trial) [default %simple]. ",
+                metavar = "model")
+  )
+  
+  opt_parser <- OptionParser(usage = "prepare_data:[version] [options]", option_list = option_list)
+  opt <- parse_args(opt_parser)
+  
+  model <- opt$model
+}
+
+################################################################################
+# 0.3 Import data
+################################################################################
+trials <- arrow::read_feather(here("output", "data", "data_seq_trials_monthly.feather"))
+trials %<>%
+  mutate(trial = factor(trial, levels = 0:4),
+         period = factor(period, levels = 1:12))
+
+################################################################################
+# 1.0 IPACW
+################################################################################
+trials_arm0_treatmentwindow <-
+  trials %>%
+  filter(arm == 0, tend <=4)  %>%
+  group_by(patient_id, trial) %>%
+  mutate(treatment_seq_lead1 = lead(treatment_seq, n = 1L, default = 1L), 
+         treatment_seq_next_equal_to_arm = if_else(treatment_seq_lead1 == arm, 1L, 0L)) %>%
+  ungroup()
+fit_num <- glm(treatment_seq_next_equal_to_arm ~ factor(tend),
+               family = binomial(link = "logit"),
+               data = trials_arm0_treatmentwindow)
+formula_denom <- 
+  paste0("treatment_seq_next_equal_to_arm ~ ",
+         paste0(c("factor(tend) + period + trial", covars), 
+                collapse = " + ")) %>%  
+  as.formula()
+fit_denom <- glm(formula_denom,
+                 family = binomial(link = "logit"),
+                 data = trials_arm0_treatmentwindow)
+trials_arm0_treatmentwindow <-
+  trials_arm0_treatmentwindow %>%
+  mutate(ipacw_num = predict(fit_num, type = "response", newdata = .),
+         ipacw_denom = predict(fit_denom, type = "response", newdata = .)) %>%
+  select(patient_id, tstart, tend, trial, ipacw_num, ipacw_denom, treatment_seq_lead1, treatment_seq_next_equal_to_arm)
+
+trials <-
+  trials %>%
+  left_join(trials_arm0_treatmentwindow,
+            by = c("patient_id", "tstart", "tend", "trial")) %>%
+  mutate(
+    ipacw = case_when(arm == 1 ~ 1,
+                      arm == 0 & tend > 4 ~ 1,
+                      arm == 0 & tend <= 4 ~ ipacw_num / ipacw_denom)) %>%
+  group_by(patient_id, trial) %>%
+  mutate(
+    ipacw_lag1 = lag(ipacw, n = 1L, default = 1),
+    ipacw_cum = cumprod(ipacw_lag1)) %>%
+  ungroup()
+
+################################################################################
+# 1.0 Outcome model
+################################################################################
+if (model == "simple"){
+  f <- 
+    paste0("status_seq ~ ",
+           paste0(c("arm + ns(tend, 4) + period + trial", covars),
+                  collapse = " + ")) %>%  
+    as.formula()
+} else if (model == "interaction_period"){
+  f <-
+    paste0("status_seq ~ ",
+           paste0(c("arm + ns(tend, 4) + period + trial + arm:period", covars),
+                  collapse = " + ")) %>%  
+    as.formula()
+} else if (model == "interaction_trial"){
+  f <-
+    paste0("status_seq ~ ",
+           paste0(c("arm + ns(tend, 4) + period + trial + arm:trial", covars),
+                  collapse = " + ")) %>%  
+    as.formula()
+} else if (model == "interaction_all"){
+  f <-
+    paste0("status_seq ~ ",
+           paste0(c("arm + ns(tend, 4) + period + trial + arm:period + arm:trial", covars),
+                  collapse = " + ")) %>%  
+    as.formula()
+}
+print("Fit outcome model")
+tic()
+om_fit <-
+  glm(f, 
+      family = binomial(link = "logit"),
+      data = trials_monthly)
+toc()
+print("Estimate robust standard errors")
+tic()
+om_fit_robust <-
+  coeftest(om_fit,
+           vcovHC)
+toc()
+print("Tidy output")
+tic()
+om_fit_robust_tidy <- 
+  om_fit_robust %>%
+  tidy(conf.int = TRUE) %>%
+  mutate(OR = exp(estimate),
+         OR_lci = exp(conf.low),
+         OR_hci = exp(conf.high))
+toc()
+
+################################################################################
+# 2.0 Save output
+################################################################################
+print("Write output")
+tic()
+saveRDS(
+  om_fit,
+  fs::path(output_dir, paste0("itt_fit_", model, ".rds"))
+)
+data.table::fwrite(
+  om_fit_robust_tidy,
+  fs::path(output_dir, paste0("itt_fit_", model, ".csv"))
+)
+toc()

--- a/analysis/seq_trials/select_and_simplify_data.R
+++ b/analysis/seq_trials/select_and_simplify_data.R
@@ -36,6 +36,7 @@ data <-
          tb_postest_treat_seq_sotmol,
          treatment_seq_sotmol,
          fup_seq,
+         covid_test_positive_date,
          all_of(covars),
          dplyr::starts_with("period_"))
 

--- a/project.yaml
+++ b/project.yaml
@@ -309,3 +309,21 @@ actions:
       moderately_sensitive:
         csv1: output/seq_trials/itt/curves/itt_survcurves_simple.csv
         csv2: output/seq_trials/itt/curves/itt_diffcurve_simple.csv
+
+  ## # # # # # # # # # # # # # # # # # # # 
+  ## # # # # # # # # # # # # # # # # # # # 
+  ## Sequential trials - PP
+  ## # # # # # # # # # # # # # # # # # # # 
+  ## # # # # # # # # # # # # # # # # # # #
+
+  run_pp_analysis_simple:
+    run: r:latest analysis/seq_trials/pp_analysis.R --model=simple
+    needs: [data_prepare_seq_trials_month]
+    outputs:
+      highly_sensitive:
+        rds1: output/seq_trials/pp/pp_fit_simple.rds
+        rds2: output/seq_trials/pp/pp_vcov_simple.rds
+      moderately_sensitive:
+        csv1: output/seq_trials/pp/pp_fit_simple.csv
+        csv2: output/seq_trials/pp/pp_glance_simple.csv
+        txt: output/seq_trials/pp/log/pp_log_simple.txt


### PR DESCRIPTION
Initial per-protocol analysis, where:
- Individuals starting treatment during follow-up in the untreated arm are censored
- Censored individuals are upweighted against their inverse probability of artificial weighting
- Weights are non-stabilised and use baseline covariates